### PR TITLE
add rdfs and fix rdf:label namespace

### DIFF
--- a/xslt/GML2RDF.xsl
+++ b/xslt/GML2RDF.xsl
@@ -17,6 +17,7 @@
     xmlns="http://www.opengis.net/gml/3.2"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:xs="http://www.w3.org/TR/2008/REC-xml-20081126#"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 	xmlns:geo="http://www.opengis.net/ont/geosparql#"
@@ -77,8 +78,8 @@
 				<xsl:value-of select="concat($baseURI, $id)" />
 			</xsl:attribute>
 		
-			<!-- EDIT: Create 'rdf:label' element with a particular attribute -->
-			<xsl:element name='rdf:label'>
+			<!-- EDIT: Create 'rdfs:label' element with a particular attribute -->
+			<xsl:element name='rdfs:label'>
 				<xsl:value-of select='ogr:arot' />
 			</xsl:element>
 			

--- a/xslt/KML2RDF.xsl
+++ b/xslt/KML2RDF.xsl
@@ -16,6 +16,7 @@
     xmlns="http://www.opengis.net/kml/2.2"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
 	xmlns:xs="http://www.w3.org/TR/2008/REC-xml-20081126#"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 	xmlns:geo="http://www.opengis.net/ont/geosparql#"
@@ -66,8 +67,8 @@
 				<xsl:value-of select="concat($baseURI, $id)" />
 			</xsl:attribute>
 		
-			<!-- Create 'rdf:label' element with the 'name' attribute -->
-			<xsl:element name='rdf:label'>
+			<!-- Create 'rdfs:label' element with the 'name' attribute -->
+			<xsl:element name='rdfs:label'>
 				<xsl:value-of select='*:name' />
 			</xsl:element>
 			


### PR DESCRIPTION
Hi, 
I noticed the definition of rdf:label should be rdfs:label. Here is the fix. 
However I'm testing the sample.kml file and the generated RDF has a weird error:
(line 32 column 37): {E202} Expecting XML start or end element(s). String data "normalhighlight" not allowed. Maybe a striping error.
I couldn't find where to fix this on the xslt... :( 
